### PR TITLE
Fixes crontab harvest run

### DIFF
--- a/contrib/my_init.d/50_setup_cron
+++ b/contrib/my_init.d/50_setup_cron
@@ -3,6 +3,6 @@ set -eu
 : ${MONGO_URL:=mongodb://mongo/registry}
 : ${CRON_STRING:=0 0 * * *}
 
-echo "${CRON_STRING} harvest catalog-harvest -s \"${MONGO_URL}\" -d /data -v >> /var/log/harvest/harvest.log 2>&1" > /etc/crontab
+echo "${CRON_STRING} harvest PATH="$PATH:/usr/local/bin" catalog-harvest -s \"${MONGO_URL}\" -d /data -v >> /var/log/harvest/harvest.log 2>&1" > /etc/crontab
 
 echo "Ready"


### PR DESCRIPTION
Fixes harvesting called from crontab by setting path correctly.
Previously cron's environment did not include /usr/local/bin, which
caused the harvest script to not be found.
