### PR TITLE
Fixes the comparison of bbox corners

### DIFF
--- a/catalog_harvesting/records.py
+++ b/catalog_harvesting/records.py
@@ -192,14 +192,16 @@ def patch_geometry(location):
 
     should_patch = False
 
-    if ll_lon == ur_lon:
-        ll_lon.text = str(float(ll_lon.text) - 0.00001)
-        ur_lon.text = str(float(ur_lon.text) + 0.00001)
+    epsilon = 0.00001
+
+    if abs(bbox[0][0] - bbox[1][0]) < epsilon:
+        ll_lon.text = str(float(ll_lon.text) - epsilon)
+        ur_lon.text = str(float(ur_lon.text) + epsilon)
         should_patch = True
 
-    if ll_lat == ur_lat:
-        ll_lat.text = str(float(ll_lat.text) - 0.00001)
-        ur_lat.text = str(float(ur_lat.text) + 0.00001)
+    if abs(bbox[0][1] - bbox[1][1]) < epsilon:
+        ll_lat.text = str(float(ll_lat.text) - epsilon)
+        ur_lat.text = str(float(ur_lat.text) + epsilon)
         should_patch = True
 
     if should_patch:


### PR DESCRIPTION
The comparison before was actually checking strings, this checks a
relative tolerance of floating point values before making an adjustment.

It works this time:

![screen shot 2017-04-28 at 11 00 15 am](https://cloud.githubusercontent.com/assets/1155163/25534499/ec5ab1e6-2c01-11e7-8bc8-5b4ff5997dd6.png)
