### PR TITLE
Fixes "infinite" loop in CSW harvest

### DIFF
--- a/catalog_harvesting/csw.py
+++ b/catalog_harvesting/csw.py
@@ -27,19 +27,20 @@ def get_records(csw, max_batches=10000):
 
     # set a maximum number of record batches just as a precaution in case
     # the CSW fails to operate correctly while fetching, for example
-    rec_offset = 0
+    position = 1
     batches = 0
     while True:
         csw.getrecords2(outputschema=namespaces['gmd'],  # Return ISO 19115 metadata
-                        startposition=rec_offset,
+                        startposition=position,
                         esn='full', maxrecords=100)
         yield csw
 
-        if csw.results['matches'] == csw.results['nextrecord'] - 1 or \
-                batches >= max_batches:
+        # nextrecord is 0 when all matches have been exhausted according to
+        # the CSW 2.0.2 spec
+        if csw.results['nextrecord'] == 0 or batches >= max_batches:
             break
 
-        rec_offset = csw.results['nextrecord']
+        position = csw.results['nextrecord']
         batches += 1
 
 


### PR DESCRIPTION
Removes an "infinite" (actually limited by max_batches parameter) loop in the
CSW harvesting code.  nextRecord is set to 0 when all the records have
been fetched, but the code was checking if nextRecord-1 was equal to the
number of matched records, which appeared to be unsatisfiable.  Thus,
redundant fetches were made until the maximum batches were exceeded.